### PR TITLE
Less laggy

### DIFF
--- a/frontend/src/views/v-summary.vue
+++ b/frontend/src/views/v-summary.vue
@@ -73,6 +73,13 @@
             v-bind:disabled="filterGroupSelection === 'groupByNone'"
           )
           span merge all groups
+        label.filter-showall
+          input.mui-checkbox(
+            type="checkbox",
+            v-model="filterShowAll",
+            v-on:change="toggleShowAll"
+          )
+          span show all
   .error-message-box(v-if="Object.entries(errorMessages).length")
     .error-message-box__close-button(v-on:click="dismissTab($event)") &times;
     .error-message-box__message The following issues occurred when analyzing the following repositories:
@@ -118,6 +125,7 @@
     v-bind:avg-contribution-size="avgContributionSize",
     v-bind:filter-group-selection="filterGroupSelection",
     v-bind:filter-breakdown="filterBreakdown",
+    v-bind:filter-showall="filterShowall",
     v-bind:filter-time-frame="filterTimeFrame",
     v-bind:filter-since-date="filterSinceDate",
     v-bind:filter-until-date="filterUntilDate",
@@ -168,6 +176,7 @@ export default {
       fileTypeColors: {},
       isSafariBrowser: /.*Version.*Safari.*/.test(navigator.userAgent),
       filterGroupSelectionWatcherFlag: false,
+      isShowingAll: false,
     };
   },
   watch: {
@@ -390,7 +399,7 @@ export default {
     },
 
     isMatchSearchedUser(filterSearch, user) {
-      return !filterSearch || filterSearch.toLowerCase()
+      return this.isShowingAll || !filterSearch || filterSearch.toLowerCase()
           .split(' ')
           .filter(Boolean)
           .some((param) => user.searchPath.includes(param));
@@ -400,6 +409,15 @@ export default {
       // Reset the file type filter
       if (this.checkedFileTypes.length !== this.fileTypes.length) {
         this.checkedFileTypes = this.fileTypes.slice();
+      }
+      this.getFiltered();
+    },
+
+    toggleShowAll() {
+      if (this.isShowingAll === true) {
+        this.isShowingAll = false;
+      } else {
+        this.isShowingAll = true;
       }
       this.getFiltered();
     },
@@ -428,7 +446,7 @@ export default {
         const res = [];
 
         // filtering
-        if (this.filterSearch !== '') {
+        if (this.isShowingAll || this.filterSearch !== '') {
           repo.users.forEach((user) => {
             if (this.isMatchSearchedUser(this.filterSearch, user)) {
               this.getUserCommits(user, this.filterSinceDate, this.filterUntilDate);

--- a/frontend/src/views/v-summary.vue
+++ b/frontend/src/views/v-summary.vue
@@ -3,7 +3,7 @@
   form.summary-picker.mui-form--inline(onsubmit="return false;")
     .summary-picker__section
       .mui-textfield.search_box
-        input(type="text", v-on:change="updateFilterSearch", v-model="filterSearch")
+        input(type="text", v-on:change="updateFilterSearch", v-model="filterSearch", :disabled="isDisabled")
         label search
         button.mui-btn.mui-btn--raised(type="button", v-on:click.prevent="resetFilterSearch") x
       .mui-select.grouping
@@ -276,6 +276,10 @@ export default {
         return this.tmpFilterUntilDate;
       }
       return this.maxDate;
+    },
+
+    isDisabled() {
+      return this.isShowingAll;
     },
 
     ...mapState(['mergedGroups']),

--- a/frontend/src/views/v-summary.vue
+++ b/frontend/src/views/v-summary.vue
@@ -428,16 +428,18 @@ export default {
         const res = [];
 
         // filtering
-        repo.users.forEach((user) => {
-          if (this.isMatchSearchedUser(this.filterSearch, user)) {
-            this.getUserCommits(user, this.filterSinceDate, this.filterUntilDate);
-            if (this.filterTimeFrame === 'week') {
-              this.splitCommitsWeek(user, this.filterSinceDate, this.filterUntilDate);
+        if (this.filterSearch !== '') {
+          repo.users.forEach((user) => {
+            if (this.isMatchSearchedUser(this.filterSearch, user)) {
+              this.getUserCommits(user, this.filterSinceDate, this.filterUntilDate);
+              if (this.filterTimeFrame === 'week') {
+                this.splitCommitsWeek(user, this.filterSinceDate, this.filterUntilDate);
+              }
+              this.updateCheckedFileTypeContribution(user);
+              res.push(user);
             }
-            this.updateCheckedFileTypeContribution(user);
-            res.push(user);
-          }
-        });
+          });
+        }
 
         if (res.length) {
           full.push(res);


### PR DESCRIPTION
I want to work on RepoSense because the page lagged very badly on my browser during CS2103T. I believe the problem is that it shows all entries and this makes the browser less responsive. As a student, I am probably only interested in seeing my/my team's data. Therefore, I show no data by default.

![Screenshot 2021-12-10 at 5 27 55 PM](https://user-images.githubusercontent.com/54730603/145550878-2e855f94-992c-4860-9bd0-41d6aee3e9ca.png)

However, the teaching team might want to see everyone's data at once. Hence, I also added another checkbox to display all students. This overrides the search field and disable (unable to show in screenshot) the user from editing the search field. This is to remind the user that the display all checkbox is selected. Otherwise, they might try to search but the result still shows everyone.

![Screenshot 2021-12-10 at 5 28 14 PM](https://user-images.githubusercontent.com/54730603/145550915-f6fb8d0c-fa6b-46e7-9c2c-353ef13b2e76.png)
